### PR TITLE
remove guava dependency

### DIFF
--- a/changelog/@unreleased/pr-22.v2.yml
+++ b/changelog/@unreleased/pr-22.v2.yml
@@ -1,0 +1,8 @@
+type: improvement
+improvement:
+  description: |-
+    remove guava dependency
+
+    I've come across multiple gradle plugins which publish a fat jar that embeds a version of ImmutableMap from an older version of guava, causing the classloader to load the older version and this code to fail (because it used a method from a newer version).
+  links:
+  - https://github.com/palantir/jakarta-package-alignment/pull/22

--- a/jakarta-package-alignment-mappings/build.gradle
+++ b/jakarta-package-alignment-mappings/build.gradle
@@ -3,6 +3,5 @@ apply plugin: "com.palantir.external-publish-jar"
 
 dependencies {
     implementation 'org.apache.maven:maven-artifact'
-    implementation 'com.google.guava:guava'
 }
 

--- a/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
+++ b/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
@@ -47,185 +47,186 @@ public final class VersionMappings {
         return mappings.values();
     }
 
+    @SuppressWarnings("checkstyle:methodlength")
     private static Map<String, VersionMapping> createMappings() {
-        Map<String, VersionMapping> mappings = new HashMap<>();
+        Map<String, VersionMapping> allMappings = new HashMap<>();
         addMapping(
-                mappings,
+                allMappings,
                 "com.sun.activation:jakarta.activation",
                 new VersionMapping(
                         new MavenCoordinate("com.sun.activation", "jakarta.activation", "1.2.2"),
                         new MavenCoordinate("com.sun.activation", "javax.activation", "1.2.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "com.sun.mail:jakarta.mail",
                 new VersionMapping(
                         new MavenCoordinate("com.sun.mail", "jakarta.mail", "1.6.7"),
                         new MavenCoordinate("com.sun.mail", "javax.mail", "1.6.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.activation:jakarta.activation-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.activation", "jakarta.activation-api", "1.2.2"),
                         new MavenCoordinate("javax.activation", "javax.activation-api", "1.2.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.annotation:jakarta.annotation-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.annotation", "jakarta.annotation-api", "1.3.5"),
                         new MavenCoordinate("javax.annotation", "javax.annotation-api", "1.3.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.batch:jakarta.batch-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.batch", "jakarta.batch-api", "1.0.2"),
                         new MavenCoordinate("javax.batch", "javax.batch-api", "1.0.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.ejb:jakarta.ejb-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.ejb", "jakarta.ejb-api", "3.2.6"),
                         new MavenCoordinate("javax.ejb", "javax.ejb-api", "3.2.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.el:jakarta.el-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.el", "jakarta.el-api", "3.0.3"),
                         new MavenCoordinate("javax.el", "javax.el-api", "3.0.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api",
                 new VersionMapping(
                         new MavenCoordinate(
                                 "jakarta.enterprise.concurrent", "jakarta.enterprise.concurrent-api", "1.1.2"),
                         new MavenCoordinate("javax.enterprise.concurrent", "javax.enterprise.concurrent-api", "1.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.faces:jakarta.faces-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.faces", "jakarta.faces-api", "2.3.2"),
                         new MavenCoordinate("javax.faces", "javax.faces-api", "2.3")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.inject:jakarta.inject-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.inject", "jakarta.inject-api", "1.0.5"),
                         new MavenCoordinate("javax.inject", "javax.inject", "1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.interceptor:jakarta.interceptor-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.interceptor", "jakarta.interceptor-api", "1.2.5"),
                         new MavenCoordinate("javax.interceptor", "javax.interceptor-api", "1.2.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.jms:jakarta.jms-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.jms", "jakarta.jms-api", "2.0.3"),
                         new MavenCoordinate("javax.jms", "javax.jms-api", "2.0.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.json.bind:jakarta.json.bind-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.json.bind", "jakarta.json.bind-api", "1.0.2"),
                         new MavenCoordinate("javax.json.bind", "javax.json.bind-api", "1.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.json:jakarta.json-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.json", "jakarta.json-api", "1.1.6"),
                         new MavenCoordinate("javax.json", "javax.json-api", "1.1.4")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.jws:jakarta.jws-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.jws", "jakarta.jws-api", "2.1.0"),
                         new MavenCoordinate("javax.jws", "javax.jws-api", "1.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.mail:jakarta.mail-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.mail", "jakarta.mail-api", "1.6.7"),
                         new MavenCoordinate("javax.mail", "javax.mail-api", "1.6.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.persistence:jakarta.persistence-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.persistence", "jakarta.persistence-api", "2.2.3"),
                         new MavenCoordinate("javax.persistence", "javax.persistence-api", "2.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.resource:jakarta.resource-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.resource", "jakarta.resource-api", "1.7.4"),
                         new MavenCoordinate("javax.resource", "javax.resource-api", "1.7.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.security.enterprise:jakarta.security.enterprise-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.security.enterprise", "jakarta.security.enterprise-api", "1.0.2"),
                         new MavenCoordinate("javax.security.enterprise", "javax.security.enterprise-api", "1.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.servlet.jsp.jstl", "jakarta.servlet.jsp.jstl-api", "1.2.7"),
                         new MavenCoordinate("javax.servlet.jsp.jstl", "javax.servlet.jsp.jstl-api", "1.2.2")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.servlet.jsp:jakarta.servlet.jsp-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.servlet.jsp", "jakarta.servlet.jsp-api", "2.3.6"),
                         new MavenCoordinate("javax.servlet.jsp", "javax.servlet.jsp-api", "2.3.3")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.servlet:jakarta.servlet-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.servlet", "jakarta.servlet-api", "4.0.4"),
                         new MavenCoordinate("javax.servlet", "javax.servlet-api", "4.0.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.transaction:jakarta.transaction-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.transaction", "jakarta.transaction-api", "1.3.3"),
                         new MavenCoordinate("javax.transaction", "javax.transaction-api", "1.3")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.validation:jakarta.validation-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.validation", "jakarta.validation-api", "2.0.2"),
                         new MavenCoordinate("javax.validation", "validation-api", "2.0.1.Final")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.websocket:jakarta.websocket-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.websocket", "jakarta.websocket-api", "1.1.2"),
                         new MavenCoordinate("javax.websocket", "javax.websocket-api", "1.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.ws.rs:jakarta.ws.rs-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.ws.rs", "jakarta.ws.rs-api", "2.1.6"),
                         new MavenCoordinate("javax.ws.rs", "javax.ws.rs-api", "2.1.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.xml.bind:jakarta.xml.bind-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3"),
                         new MavenCoordinate("javax.xml.bind", "jaxb-api", "2.3.1")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.xml.soap:jakarta.xml.soap-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.xml.soap", "jakarta.xml.soap-api", "1.4.2"),
                         new MavenCoordinate("javax.xml.soap", "javax.xml.soap-api", "1.4.0")));
         addMapping(
-                mappings,
+                allMappings,
                 "jakarta.xml.ws:jakarta.xml.ws-api",
                 new VersionMapping(
                         new MavenCoordinate("jakarta.xml.ws", "jakarta.xml.ws-api", "2.3.3"),
                         new MavenCoordinate("javax.xml.ws", "jaxws-api", "2.3.1")));
 
-        return mappings;
+        return allMappings;
     }
 
     private static void addMapping(Map<String, VersionMapping> map, String key, VersionMapping value) {

--- a/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
+++ b/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
@@ -15,164 +15,15 @@
  */
 package com.palantir.gradle.jakartapackagealignment;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.maven.artifact.versioning.ComparableVersion;
 
 public final class VersionMappings {
 
-    private static final Map<String, VersionMapping> mappings = ImmutableMap.<String, VersionMapping>builder()
-            .put(
-                    "com.sun.activation:jakarta.activation",
-                    new VersionMapping(
-                            new MavenCoordinate("com.sun.activation", "jakarta.activation", "1.2.2"),
-                            new MavenCoordinate("com.sun.activation", "javax.activation", "1.2.0")))
-            .put(
-                    "com.sun.mail:jakarta.mail",
-                    new VersionMapping(
-                            new MavenCoordinate("com.sun.mail", "jakarta.mail", "1.6.7"),
-                            new MavenCoordinate("com.sun.mail", "javax.mail", "1.6.2")))
-            .put(
-                    "jakarta.activation:jakarta.activation-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.activation", "jakarta.activation-api", "1.2.2"),
-                            new MavenCoordinate("javax.activation", "javax.activation-api", "1.2.0")))
-            .put(
-                    "jakarta.annotation:jakarta.annotation-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.annotation", "jakarta.annotation-api", "1.3.5"),
-                            new MavenCoordinate("javax.annotation", "javax.annotation-api", "1.3.2")))
-            .put(
-                    "jakarta.batch:jakarta.batch-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.batch", "jakarta.batch-api", "1.0.2"),
-                            new MavenCoordinate("javax.batch", "javax.batch-api", "1.0.1")))
-            .put(
-                    "jakarta.ejb:jakarta.ejb-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.ejb", "jakarta.ejb-api", "3.2.6"),
-                            new MavenCoordinate("javax.ejb", "javax.ejb-api", "3.2.2")))
-            .put(
-                    "jakarta.el:jakarta.el-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.el", "jakarta.el-api", "3.0.3"),
-                            new MavenCoordinate("javax.el", "javax.el-api", "3.0.0")))
-            .put(
-                    "jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api",
-                    new VersionMapping(
-                            new MavenCoordinate(
-                                    "jakarta.enterprise.concurrent", "jakarta.enterprise.concurrent-api", "1.1.2"),
-                            new MavenCoordinate(
-                                    "javax.enterprise.concurrent", "javax.enterprise.concurrent-api", "1.1")))
-            .put(
-                    "jakarta.faces:jakarta.faces-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.faces", "jakarta.faces-api", "2.3.2"),
-                            new MavenCoordinate("javax.faces", "javax.faces-api", "2.3")))
-            .put(
-                    "jakarta.inject:jakarta.inject-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.inject", "jakarta.inject-api", "1.0.5"),
-                            new MavenCoordinate("javax.inject", "javax.inject", "1")))
-            .put(
-                    "jakarta.interceptor:jakarta.interceptor-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.interceptor", "jakarta.interceptor-api", "1.2.5"),
-                            new MavenCoordinate("javax.interceptor", "javax.interceptor-api", "1.2.2")))
-            .put(
-                    "jakarta.jms:jakarta.jms-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.jms", "jakarta.jms-api", "2.0.3"),
-                            new MavenCoordinate("javax.jms", "javax.jms-api", "2.0.1")))
-            .put(
-                    "jakarta.json.bind:jakarta.json.bind-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.json.bind", "jakarta.json.bind-api", "1.0.2"),
-                            new MavenCoordinate("javax.json.bind", "javax.json.bind-api", "1.0")))
-            .put(
-                    "jakarta.json:jakarta.json-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.json", "jakarta.json-api", "1.1.6"),
-                            new MavenCoordinate("javax.json", "javax.json-api", "1.1.4")))
-            .put(
-                    "jakarta.jws:jakarta.jws-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.jws", "jakarta.jws-api", "2.1.0"),
-                            new MavenCoordinate("javax.jws", "javax.jws-api", "1.1")))
-            .put(
-                    "jakarta.mail:jakarta.mail-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.mail", "jakarta.mail-api", "1.6.7"),
-                            new MavenCoordinate("javax.mail", "javax.mail-api", "1.6.2")))
-            .put(
-                    "jakarta.persistence:jakarta.persistence-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.persistence", "jakarta.persistence-api", "2.2.3"),
-                            new MavenCoordinate("javax.persistence", "javax.persistence-api", "2.2")))
-            .put(
-                    "jakarta.resource:jakarta.resource-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.resource", "jakarta.resource-api", "1.7.4"),
-                            new MavenCoordinate("javax.resource", "javax.resource-api", "1.7.1")))
-            .put(
-                    "jakarta.security.enterprise:jakarta.security.enterprise-api",
-                    new VersionMapping(
-                            new MavenCoordinate(
-                                    "jakarta.security.enterprise", "jakarta.security.enterprise-api", "1.0.2"),
-                            new MavenCoordinate("javax.security.enterprise", "javax.security.enterprise-api", "1.0")))
-            .put(
-                    "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.servlet.jsp.jstl", "jakarta.servlet.jsp.jstl-api", "1.2.7"),
-                            new MavenCoordinate("javax.servlet.jsp.jstl", "javax.servlet.jsp.jstl-api", "1.2.2")))
-            .put(
-                    "jakarta.servlet.jsp:jakarta.servlet.jsp-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.servlet.jsp", "jakarta.servlet.jsp-api", "2.3.6"),
-                            new MavenCoordinate("javax.servlet.jsp", "javax.servlet.jsp-api", "2.3.3")))
-            .put(
-                    "jakarta.servlet:jakarta.servlet-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.servlet", "jakarta.servlet-api", "4.0.4"),
-                            new MavenCoordinate("javax.servlet", "javax.servlet-api", "4.0.1")))
-            .put(
-                    "jakarta.transaction:jakarta.transaction-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.transaction", "jakarta.transaction-api", "1.3.3"),
-                            new MavenCoordinate("javax.transaction", "javax.transaction-api", "1.3")))
-            .put(
-                    "jakarta.validation:jakarta.validation-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.validation", "jakarta.validation-api", "2.0.2"),
-                            new MavenCoordinate("javax.validation", "validation-api", "2.0.1.Final")))
-            .put(
-                    "jakarta.websocket:jakarta.websocket-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.websocket", "jakarta.websocket-api", "1.1.2"),
-                            new MavenCoordinate("javax.websocket", "javax.websocket-api", "1.1")))
-            .put(
-                    "jakarta.ws.rs:jakarta.ws.rs-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.ws.rs", "jakarta.ws.rs-api", "2.1.6"),
-                            new MavenCoordinate("javax.ws.rs", "javax.ws.rs-api", "2.1.1")))
-            .put(
-                    "jakarta.xml.bind:jakarta.xml.bind-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3"),
-                            new MavenCoordinate("javax.xml.bind", "jaxb-api", "2.3.1")))
-            .put(
-                    "jakarta.xml.soap:jakarta.xml.soap-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.xml.soap", "jakarta.xml.soap-api", "1.4.2"),
-                            new MavenCoordinate("javax.xml.soap", "javax.xml.soap-api", "1.4.0")))
-            .put(
-                    "jakarta.xml.ws:jakarta.xml.ws-api",
-                    new VersionMapping(
-                            new MavenCoordinate("jakarta.xml.ws", "jakarta.xml.ws-api", "2.3.3"),
-                            new MavenCoordinate("javax.xml.ws", "jaxws-api", "2.3.1")))
-            .buildOrThrow();
+    private static final Map<String, VersionMapping> mappings = createMappings();
 
     private VersionMappings() {}
 
@@ -194,5 +45,192 @@ public final class VersionMappings {
 
     public static Collection<VersionMapping> getMappings() {
         return mappings.values();
+    }
+
+    private static Map<String, VersionMapping> createMappings() {
+        Map<String, VersionMapping> mappings = new HashMap<>();
+        addMapping(
+                mappings,
+                "com.sun.activation:jakarta.activation",
+                new VersionMapping(
+                        new MavenCoordinate("com.sun.activation", "jakarta.activation", "1.2.2"),
+                        new MavenCoordinate("com.sun.activation", "javax.activation", "1.2.0")));
+        addMapping(
+                mappings,
+                "com.sun.mail:jakarta.mail",
+                new VersionMapping(
+                        new MavenCoordinate("com.sun.mail", "jakarta.mail", "1.6.7"),
+                        new MavenCoordinate("com.sun.mail", "javax.mail", "1.6.2")));
+        addMapping(
+                mappings,
+                "jakarta.activation:jakarta.activation-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.activation", "jakarta.activation-api", "1.2.2"),
+                        new MavenCoordinate("javax.activation", "javax.activation-api", "1.2.0")));
+        addMapping(
+                mappings,
+                "jakarta.annotation:jakarta.annotation-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.annotation", "jakarta.annotation-api", "1.3.5"),
+                        new MavenCoordinate("javax.annotation", "javax.annotation-api", "1.3.2")));
+        addMapping(
+                mappings,
+                "jakarta.batch:jakarta.batch-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.batch", "jakarta.batch-api", "1.0.2"),
+                        new MavenCoordinate("javax.batch", "javax.batch-api", "1.0.1")));
+        addMapping(
+                mappings,
+                "jakarta.ejb:jakarta.ejb-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.ejb", "jakarta.ejb-api", "3.2.6"),
+                        new MavenCoordinate("javax.ejb", "javax.ejb-api", "3.2.2")));
+        addMapping(
+                mappings,
+                "jakarta.el:jakarta.el-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.el", "jakarta.el-api", "3.0.3"),
+                        new MavenCoordinate("javax.el", "javax.el-api", "3.0.0")));
+        addMapping(
+                mappings,
+                "jakarta.enterprise.concurrent:jakarta.enterprise.concurrent-api",
+                new VersionMapping(
+                        new MavenCoordinate(
+                                "jakarta.enterprise.concurrent", "jakarta.enterprise.concurrent-api", "1.1.2"),
+                        new MavenCoordinate("javax.enterprise.concurrent", "javax.enterprise.concurrent-api", "1.1")));
+        addMapping(
+                mappings,
+                "jakarta.faces:jakarta.faces-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.faces", "jakarta.faces-api", "2.3.2"),
+                        new MavenCoordinate("javax.faces", "javax.faces-api", "2.3")));
+        addMapping(
+                mappings,
+                "jakarta.inject:jakarta.inject-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.inject", "jakarta.inject-api", "1.0.5"),
+                        new MavenCoordinate("javax.inject", "javax.inject", "1")));
+        addMapping(
+                mappings,
+                "jakarta.interceptor:jakarta.interceptor-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.interceptor", "jakarta.interceptor-api", "1.2.5"),
+                        new MavenCoordinate("javax.interceptor", "javax.interceptor-api", "1.2.2")));
+        addMapping(
+                mappings,
+                "jakarta.jms:jakarta.jms-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.jms", "jakarta.jms-api", "2.0.3"),
+                        new MavenCoordinate("javax.jms", "javax.jms-api", "2.0.1")));
+        addMapping(
+                mappings,
+                "jakarta.json.bind:jakarta.json.bind-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.json.bind", "jakarta.json.bind-api", "1.0.2"),
+                        new MavenCoordinate("javax.json.bind", "javax.json.bind-api", "1.0")));
+        addMapping(
+                mappings,
+                "jakarta.json:jakarta.json-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.json", "jakarta.json-api", "1.1.6"),
+                        new MavenCoordinate("javax.json", "javax.json-api", "1.1.4")));
+        addMapping(
+                mappings,
+                "jakarta.jws:jakarta.jws-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.jws", "jakarta.jws-api", "2.1.0"),
+                        new MavenCoordinate("javax.jws", "javax.jws-api", "1.1")));
+        addMapping(
+                mappings,
+                "jakarta.mail:jakarta.mail-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.mail", "jakarta.mail-api", "1.6.7"),
+                        new MavenCoordinate("javax.mail", "javax.mail-api", "1.6.2")));
+        addMapping(
+                mappings,
+                "jakarta.persistence:jakarta.persistence-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.persistence", "jakarta.persistence-api", "2.2.3"),
+                        new MavenCoordinate("javax.persistence", "javax.persistence-api", "2.2")));
+        addMapping(
+                mappings,
+                "jakarta.resource:jakarta.resource-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.resource", "jakarta.resource-api", "1.7.4"),
+                        new MavenCoordinate("javax.resource", "javax.resource-api", "1.7.1")));
+        addMapping(
+                mappings,
+                "jakarta.security.enterprise:jakarta.security.enterprise-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.security.enterprise", "jakarta.security.enterprise-api", "1.0.2"),
+                        new MavenCoordinate("javax.security.enterprise", "javax.security.enterprise-api", "1.0")));
+        addMapping(
+                mappings,
+                "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.servlet.jsp.jstl", "jakarta.servlet.jsp.jstl-api", "1.2.7"),
+                        new MavenCoordinate("javax.servlet.jsp.jstl", "javax.servlet.jsp.jstl-api", "1.2.2")));
+        addMapping(
+                mappings,
+                "jakarta.servlet.jsp:jakarta.servlet.jsp-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.servlet.jsp", "jakarta.servlet.jsp-api", "2.3.6"),
+                        new MavenCoordinate("javax.servlet.jsp", "javax.servlet.jsp-api", "2.3.3")));
+        addMapping(
+                mappings,
+                "jakarta.servlet:jakarta.servlet-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.servlet", "jakarta.servlet-api", "4.0.4"),
+                        new MavenCoordinate("javax.servlet", "javax.servlet-api", "4.0.1")));
+        addMapping(
+                mappings,
+                "jakarta.transaction:jakarta.transaction-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.transaction", "jakarta.transaction-api", "1.3.3"),
+                        new MavenCoordinate("javax.transaction", "javax.transaction-api", "1.3")));
+        addMapping(
+                mappings,
+                "jakarta.validation:jakarta.validation-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.validation", "jakarta.validation-api", "2.0.2"),
+                        new MavenCoordinate("javax.validation", "validation-api", "2.0.1.Final")));
+        addMapping(
+                mappings,
+                "jakarta.websocket:jakarta.websocket-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.websocket", "jakarta.websocket-api", "1.1.2"),
+                        new MavenCoordinate("javax.websocket", "javax.websocket-api", "1.1")));
+        addMapping(
+                mappings,
+                "jakarta.ws.rs:jakarta.ws.rs-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.ws.rs", "jakarta.ws.rs-api", "2.1.6"),
+                        new MavenCoordinate("javax.ws.rs", "javax.ws.rs-api", "2.1.1")));
+        addMapping(
+                mappings,
+                "jakarta.xml.bind:jakarta.xml.bind-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.xml.bind", "jakarta.xml.bind-api", "2.3.3"),
+                        new MavenCoordinate("javax.xml.bind", "jaxb-api", "2.3.1")));
+        addMapping(
+                mappings,
+                "jakarta.xml.soap:jakarta.xml.soap-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.xml.soap", "jakarta.xml.soap-api", "1.4.2"),
+                        new MavenCoordinate("javax.xml.soap", "javax.xml.soap-api", "1.4.0")));
+        addMapping(
+                mappings,
+                "jakarta.xml.ws:jakarta.xml.ws-api",
+                new VersionMapping(
+                        new MavenCoordinate("jakarta.xml.ws", "jakarta.xml.ws-api", "2.3.3"),
+                        new MavenCoordinate("javax.xml.ws", "jaxws-api", "2.3.1")));
+
+        return mappings;
+    }
+
+    private static void addMapping(Map<String, VersionMapping> map, String key, VersionMapping value) {
+        if (map.putIfAbsent(key, value) != null) {
+            throw new IllegalArgumentException("duplicate key: " + key);
+        }
     }
 }

--- a/versions.lock
+++ b/versions.lock
@@ -1,13 +1,6 @@
 # Run ./gradlew --write-locks to regenerate this file
-com.google.code.findbugs:jsr305:3.0.2 (2 constraints: 1d0fb186)
-com.google.errorprone:error_prone_annotations:2.11.0 (2 constraints: 7b0f13a1)
-com.google.guava:failureaccess:1.0.1 (1 constraints: 140ae1b4)
-com.google.guava:guava:31.1-jre (1 constraints: 47069c47)
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
-com.google.j2objc:j2objc-annotations:1.3 (1 constraints: b809eda0)
 org.apache.commons:commons-lang3:3.8.1 (1 constraints: 8d0d772f)
 org.apache.maven:maven-artifact:3.9.0 (1 constraints: 0e051536)
-org.checkerframework:checker-qual:3.30.0 (2 constraints: 7f0f67a1)
 org.codehaus.plexus:plexus-utils:3.4.2 (1 constraints: 8a0d6c2f)
 
 [Test dependencies]

--- a/versions.props
+++ b/versions.props
@@ -1,6 +1,5 @@
 com.netflix.nebula:nebula-test = 10.0.0
 org.apache.maven:maven-artifact = 3.9.0
-com.google.guava:guava = 31.1-jre
 
 # conflict resolution
 com.google.code.findbugs:jsr305 = 3.0.2


### PR DESCRIPTION
I've come across multiple gradle plugins which publish a fat jar that embeds a version of ImmutableMap from an older version of guava, causing the classloader to load the older version and this code to fail (because it used a method from a newer version).