### PR TITLE
fix issue with getReplacement when version is empty string

### DIFF
--- a/changelog/@unreleased/pr-26.v2.yml
+++ b/changelog/@unreleased/pr-26.v2.yml
@@ -1,0 +1,12 @@
+type: fix
+fix:
+  description: |-
+    fix issue with getReplacement when version is empty string
+
+    It is possible that JakartaPackageAlignmentPlugin will call getReplacement with an empty string for the version. Previously, this code would erroneously return a replacement version because the comparator for ComparableVersion returns -1 when an empty string is compared with the maximum Jakarta version.
+
+    To address that, only look for a replacement when the version is non-null and non-empty.
+
+    Fixes #25
+  links:
+  - https://github.com/palantir/jakarta-package-alignment/pull/26

--- a/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
+++ b/jakarta-package-alignment-mappings/src/main/java/com/palantir/gradle/jakartapackagealignment/VersionMappings.java
@@ -28,6 +28,14 @@ public final class VersionMappings {
     private VersionMappings() {}
 
     public static Optional<MavenCoordinate> getReplacement(String group, String name, String version) {
+        // https://github.com/palantir/jakarta-package-alignment/issues/25
+        // we must have non-null, non-empty version, otherwise the version comparison below
+        // can return the incorrect result
+        // this can happen if getReplacement is called from a ModuleComponentSelector that only has the group/name set
+        if (version == null || version.isEmpty()) {
+            return Optional.empty();
+        }
+
         String key = group + ":" + name;
         VersionMapping mapping = mappings.get(key);
 


### PR DESCRIPTION
It is possible that JakartaPackageAlignmentPlugin will call getReplacement with an empty string for the version. Previously, this code would erroneously return a replacement version because the comparator for ComparableVersion returns -1 when an empty string is compared with the maximum Jakarta version.

To address that, only look for a replacement when the version is non-null and non-empty.

Fixes #25